### PR TITLE
remove ssh-config for www-data and set a global ssh_config for all users

### DIFF
--- a/src/php-fpm/Dockerfile
+++ b/src/php-fpm/Dockerfile
@@ -3,7 +3,7 @@ FROM php:7.2.13-fpm-alpine
 COPY ./php.ini /usr/local/etc/php/php.ini
 
 COPY ./.bashrc /home/www-data/.bashrc
-COPY ./ssh_config /home/www-data/.ssh/config
+COPY ./ssh_config /etc/ssh/ssh_config
 
 COPY ./provision.sh /provision.sh
 

--- a/src/php-fpm/provision.sh
+++ b/src/php-fpm/provision.sh
@@ -120,12 +120,6 @@ curl -sS https://getcomposer.org/installer | php -- \
 composer global require hirak/prestissimo
 
 #
-# Set correct permissions for SSH config
-#
-chown -R www-data:www-data /home/www-data/.ssh
-chmod 0600 /home/www-data/.ssh/config
-
-#
 # Set correct permissions for .bashrc
 #
 chown www-data:www-data /home/www-data/.bashrc


### PR DESCRIPTION
If we have additional users in our container, we need a ssh config for all of them. The goal is to use the same ssh key from host with every user.